### PR TITLE
Replaced node's 'url' module with 'url-parse' to support 'dat://' in node.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,6 @@
 /* globals window process console URL */
 const AwaitLock = require('await-lock')
-const URL = (typeof window === 'undefined') ? require('url').URL : URL
+const URL = (typeof window === 'undefined') ? require('url-parse') : URL
 
 // read log level from the environment
 const LOG_LEVEL = (typeof window === 'undefined'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "level-promise": "^2.1.1",
     "level-sublevel": "^6.6.1",
     "lodash.flatten": "^4.4.0",
+    "url-parse": "^1.1.9",    
     "tempy": "^0.1.0",
     "through2": "^2.0.3"
   },


### PR DESCRIPTION
Fixes: https://github.com/beakerbrowser/ingestdb/issues/2